### PR TITLE
1. Clear one notification 2. Save to file 3. send all cached notifications at once

### DIFF
--- a/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
@@ -35,7 +35,8 @@ public class BackgroundActionButtonHandler extends BroadcastReceiver implements 
                 originalExtras.putString(INLINE_REPLY, inputString);
             }
 
-            PushPlugin.sendExtras(originalExtras);
+            
+            PushPlugin.sendExtras(context, null, originalExtras);
         }
      }
 }

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -80,7 +80,8 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                 Log.d(LOG_TAG, "foreground");
                 extras.putBoolean(FOREGROUND, true);
                 extras.putBoolean(COLDSTART, false);
-                PushPlugin.sendExtras(extras);
+                
+                PushPlugin.sendExtras(getApplicationContext(), null, extras);
             }
             // if we are in the foreground and forceShow is `true`, force show the notification if the data has at least a message or title
             else if (forceShow && PushPlugin.isInForeground()) {
@@ -312,7 +313,8 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
 		} else if ("1".equals(contentAvailable)) {
             Log.d(LOG_TAG, "app is not running and content available true");
             Log.d(LOG_TAG, "send notification event");
-            PushPlugin.sendExtras(extras);
+            
+            PushPlugin.sendExtras(getApplicationContext(), null, extras);
         }
     }
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -59,6 +59,7 @@ public interface PushConstants {
     public static final String CONTENT_AVAILABLE = "content-available";
     public static final String TOPICS = "topics";
     public static final String SET_APPLICATION_ICON_BADGE_NUMBER = "setApplicationIconBadgeNumber";
+    public static final String CLEAR_NOTIFICATION = "clearNotification"; 
     public static final String CLEAR_ALL_NOTIFICATIONS = "clearAllNotifications";
     public static final String VISIBILITY = "visibility";
     public static final String INLINE_REPLY = "inlineReply";

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -81,7 +81,8 @@ public class PushHandlerActivity extends Activity implements PushConstants {
                 originalExtras.putString(INLINE_REPLY, inputString);
             }
 
-            PushPlugin.sendExtras(originalExtras);
+            
+            PushPlugin.sendExtras(getApplicationContext(), null, originalExtras);
         }
         return remoteInput == null;
     }

--- a/www/push.js
+++ b/www/push.js
@@ -185,6 +185,29 @@ PushNotification.prototype.getApplicationIconBadgeNumber = function(successCallb
  * Get the application icon badge
  */
 
+PushNotification.prototype.clearNotification = function(successCallback, errorCallback, notId) {
+    if (!successCallback) { successCallback = function() {}; }
+    if (!errorCallback) { errorCallback = function() {}; }
+
+    if (typeof errorCallback !== 'function')  {
+        console.log('PushNotification.clearNotification failure: failure parameter not a function');
+        return;
+    }
+
+    if (typeof successCallback !== 'function') {
+        console.log('PushNotification.clearNotification failure: success callback parameter must be a function');
+        return;
+    }
+
+    exec(successCallback, errorCallback, 'PushNotification', 'clearNotification', [{notId: notId}]);
+};
+
+
+
+/**
+ * Get the application icon badge
+ */
+
 PushNotification.prototype.clearAllNotifications = function(successCallback, errorCallback) {
     if (!successCallback) { successCallback = function() {}; }
     if (!errorCallback) { errorCallback = function() {}; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Made the following enhancement to the android plugin:
1. Added clearAllNotifications as currently only clearAllNotifications
2. Saved notifications to file as currently when the phone restarts and the app is closed all unhandled notification will be lost. By saving them to file, the plugin reads the notification back from file when it first starts so notifications will not be lost.
3. Sending all cached notifications as one array instead of sending each one individually. This allows your app to determine which view to go to. 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Only want to clear certain notifications and not all of them. Based on notification id process, only that notification will be cleared from the tray.
2. When phone restarts all cached notifications are lost when app is closed. The plugin currently keeps the cached notifications in memory so they will be lost if phone is restarted without opening the app first. Solution store to file and read from file on app started or first notification received.
3. When we start the app there could be multiple notification that were cached and currently there is not way to tell which view to take the user too. By grouping all cached notifications and sending them to app as an array, the app can process them and decided which view to take the user to. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. We sent two notifications with two ids and only called ClearNotification on one of them and the second one remained in the tray.
2. We sent bunch of notifications with app closed. Restarted the phone then opened the app, and all notifications were processed successfully.
3. Sent bunch of notifications when app is closed, when we opened the app, it received them all as one array. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

